### PR TITLE
Fix missing React hook dependencies

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -411,7 +411,7 @@ function InstructorPanel({ room }) {
       saveRoomRound(room, r2);
       setRound(r2);
     }
-  }, [round?.isOpen]);
+  }, [round, room, roster, setRound]);
 
   // Preview scenario (for SP) or generated nodes (for other modes)
   const baseScenario =
@@ -1395,7 +1395,7 @@ function useWeightedScenario(scenario, round) {
       return [u, v, w, mode];
     });
     return applyModifiers({ ...scenario, edges: withW });
-  }, [scenario, round?.objectiveMode, round?.objA, round?.objB, round?.alpha]);
+  }, [scenario, round]);
 
   const opt = useMemo(
     () => dijkstra(scenario.nodes, graphEdges, scenario.start, scenario.end),


### PR DESCRIPTION
## Summary
- ensure scoring effect reruns when round, room, or roster change
- recompute weighted graph edges when round settings update

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4b4dbedf08326a01b46d381e1765c