### PR TITLE
Handle missing Supabase env vars

### DIFF
--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -1,4 +1,12 @@
 import { createClient } from '@supabase/supabase-js';
-const url = import.meta.env.VITE_SUPABASE_URL;
-const key = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+// Allow the app to run even if Supabase environment variables are missing.
+// Vite replaces `import.meta.env` at build time, but when the values are
+// undefined the `createClient` call would throw and the whole app would render
+// a blank screen.  Fall back to harmless demo values so the UI can still load
+// during local development.
+const env = import.meta?.env ?? {};
+const url = env.VITE_SUPABASE_URL || 'https://example.com';
+const key = env.VITE_SUPABASE_ANON_KEY || 'public-anon-key';
+
 export const supabase = createClient(url, key);


### PR DESCRIPTION
## Summary
- Prevent crash when Supabase environment variables are absent by providing safe defaults

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4d39490d48326ad5d8d2fc4522373