### PR TITLE
Use env instructor pin and add standings tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ It helps students wake up in morning lectures and learn key logistics concepts b
   - **Traveling Salesperson (TSP)**.
   - **Vehicle Routing Problem (VRP)** with capacity constraints.
   - **Warehouse Order-Picking** with Manhattan distance.
-- Leaderboard with cumulative season points:
-  - `points = 20 – placement` (e.g., 1st = 19 pts).
+  - Leaderboard with cumulative season points:
+    - `points = 24 – placement` (e.g., 1st = 23 pts).
 - Student login via **username + PIN** (from CSV roster).
 - Persistent data storage with **Supabase** (does not reset on redeploy).
 - Export round/season results to CSV.
@@ -37,7 +37,7 @@ It helps students wake up in morning lectures and learn key logistics concepts b
 - **Base:** `1000 × (optimal cost ÷ your cost)`.
 - **Time bonus:** `max(0, 200 − seconds used)`.
 - **Total score:** base + time bonus (higher is better).
-- **Goal:** maximize your score to rank high and earn season points (`20 − place`).
+- **Goal:** maximize your score to rank high and earn season points (`24 − place`).
 
 ---
 
@@ -57,7 +57,8 @@ It helps students wake up in morning lectures and learn key logistics concepts b
 3. Create `.env.local`:
    ```env
    VITE_SUPABASE_URL=your_supabase_url
-   VITE_SUPABASE_ANON_KEY=your_supabase_key
+    VITE_SUPABASE_ANON_KEY=your_supabase_key
+    VITE_INSTRUCTOR_PIN=your_secret_pin
    ```
 
 4. Run dev server:
@@ -132,8 +133,8 @@ Custom domain? Point `scma.shahsahebi.com` (CNAME) → Vercel.
 
 - **Round Score:** `score = 1000 × (baseline / your cost) + max(0, 200 − time in seconds)`.
 - **Season Points:**
-  - Placement → `20 – rank`.
-  - Example: 1st = 19 pts, 5th = 15 pts, ≥20th = 0.
+  - Placement → `24 – rank`.
+  - Example: 1st = 23 pts, 5th = 19 pts, ≥24th = 0.
 - Non-submitters get **0**.
 
 ---

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.57.4",
@@ -27,6 +28,7 @@
     "globals": "^16.3.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.13",
-    "vite": "^7.1.2"
+    "vite": "^7.1.2",
+    "vitest": "^1.6.0"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,12 @@
 import React, { useMemo, useRef, useState, useEffect } from "react";
+import { computeStandings } from "./lib/standings";
 
 /**
  * SCMA Morning Dash — Shortest Path Race (v2)
  * -------------------------------------------------------------
  * New in v2 (your requests):
  * 1) Persistent season leaderboard that accumulates points across rounds
- *    - Round points = max(0, 20 - place). Non-submitters get 0.
+ *    - Round points = max(0, 24 - place). Non-submitters get 0.
  * 2) Instructor-set countdown per round; auto-close when timer ends.
  * 3) Instructor can generate a custom network with a chosen node count.
  * 4) Sleeker UI sections for Round vs Season leaderboards + CSV exports.
@@ -15,7 +16,7 @@ import React, { useMemo, useRef, useState, useEffect } from "react";
  * - For class-scale real-time, we’ll wire Supabase next (drop-in).
  */
 
-const INSTRUCTOR_PIN = "13741374";
+const INSTRUCTOR_PIN = import.meta.env.VITE_INSTRUCTOR_PIN;
 
 // -----------------------------
 // Static Scenarios (you can still use these)
@@ -2147,14 +2148,6 @@ function downloadCsv(csv, filename) {
   const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
   const url = URL.createObjectURL(blob); const a = document.createElement("a");
   a.href = url; a.download = filename; a.click(); URL.revokeObjectURL(url);
-}
-
-// Season scoring
-function computeStandings(round) {
-  const entries = Object.entries(round.players || {}).map(([name, r]) => ({ name, ...r }));
-  entries.sort((a, b) => b.score - a.score || a.timeSec - b.timeSec);
-  const standings = entries.map((e, i) => ({ ...e, rank: i + 1, points: Math.max(0, 24 - (i + 1)) }));
-  return standings;
 }
 
 async function applySeasonPoints(room, round, standings /* array */) {

--- a/src/lib/standings.js
+++ b/src/lib/standings.js
@@ -1,0 +1,5 @@
+export function computeStandings(round) {
+  const entries = Object.entries(round.players || {}).map(([name, r]) => ({ name, ...r }));
+  entries.sort((a, b) => b.score - a.score || a.timeSec - b.timeSec);
+  return entries.map((e, i) => ({ ...e, rank: i + 1, points: Math.max(0, 24 - (i + 1)) }));
+}

--- a/src/lib/standings.test.js
+++ b/src/lib/standings.test.js
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { computeStandings } from './standings';
+
+describe('computeStandings', () => {
+  it('sorts players and assigns ranks and points', () => {
+    const round = {
+      players: {
+        alice: { score: 100, timeSec: 10 },
+        bob: { score: 100, timeSec: 20 },
+        carol: { score: 90, timeSec: 5 }
+      }
+    };
+    const standings = computeStandings(round);
+    expect(standings[0]).toMatchObject({ name: 'alice', rank: 1, points: 23 });
+    expect(standings[1]).toMatchObject({ name: 'bob', rank: 2, points: 22 });
+    expect(standings[2]).toMatchObject({ name: 'carol', rank: 3, points: 21 });
+  });
+});


### PR DESCRIPTION
## Summary
- Load instructor PIN from environment instead of hard-coding
- Document season points as `24 – rank` and note instructor PIN in setup
- Add `computeStandings` helper with unit test scaffold

## Testing
- `npm run lint`
- `npm test` *(fails: `vitest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68c72b92c4608326a7b4b299e6eeff75